### PR TITLE
Balance changes

### DIFF
--- a/Assets/Data/Attributes/Bullets/CyanBullet.asset
+++ b/Assets/Data/Attributes/Bullets/CyanBullet.asset
@@ -24,11 +24,11 @@ MonoBehaviour:
     _variable: {fileID: 0}
   maxDamageVariation:
     _useConstant: 1
-    _constant: 50
+    _constant: 25
     _variable: {fileID: 0}
   speed:
     _useConstant: 1
-    _constant: 40
+    _constant: 70
     _variable: {fileID: 0}
   impactRadius:
     _useConstant: 1

--- a/Assets/Data/Attributes/Ships/Cyan Summon.asset
+++ b/Assets/Data/Attributes/Ships/Cyan Summon.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   description: "Cyan ship summoned by the player\t"
   prefab: {fileID: 6527832755920852042, guid: 11e3d12220070db448013d4968149cff, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_cyan
   shipColor:
     _useConstant: 1
     _constant: {r: 0, g: 0, b: 0, a: 0}
@@ -29,7 +29,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   maxShield:
     _useConstant: 1
-    _constant: 95
+    _constant: 145
     _variable: {fileID: 0}
   shieldRegen:
     _useConstant: 1
@@ -41,11 +41,11 @@ MonoBehaviour:
     _variable: {fileID: 0}
   damageMultiplier:
     _useConstant: 1
-    _constant: 1
+    _constant: 1.5
     _variable: {fileID: 0}
   speed:
     _useConstant: 1
-    _constant: 0.005
+    _constant: 0.006
     _variable: {fileID: 0}
   defense:
     _useConstant: 1
@@ -73,7 +73,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   graphiteCostIncrease:
     _useConstant: 1
-    _constant: 15
+    _constant: 0
     _variable: {fileID: 0}
   maximumShips:
     _useConstant: 1
@@ -85,5 +85,5 @@ MonoBehaviour:
     _variable: {fileID: 0}
   orbitRadius:
     _useConstant: 1
-    _constant: 3
+    _constant: 7.5
     _variable: {fileID: 0}

--- a/Assets/Data/Attributes/Ships/Enemies/Lime Ship.asset
+++ b/Assets/Data/Attributes/Ships/Enemies/Lime Ship.asset
@@ -61,9 +61,9 @@ MonoBehaviour:
     _variable: {fileID: 0}
   dropMinMaxCount:
     _useConstant: 1
-    _constant: {x: 15, y: 40}
+    _constant: {x: 3, y: 5}
     _variable: {fileID: 0}
-  shellDrop: {fileID: 4108485770172352479, guid: 12680e9855c37684ea4f9c7f37017a4f, type: 3}
+  shellDrop: {fileID: 4108485770172352479, guid: fad4cddbc0564f344aebf02278f79d7c, type: 3}
   fire: {fileID: 11400000, guid: cd4b2ca9005c76547a9411386cf0ced0, type: 2}
   hitSound: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Data/Attributes/Ships/Enemies/Orange Ship.asset
+++ b/Assets/Data/Attributes/Ships/Enemies/Orange Ship.asset
@@ -20,18 +20,18 @@ MonoBehaviour:
 
 '
   prefab: {fileID: 5494245065721851808, guid: 21e2cc9b4613d6a4885257bee7967117, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_orange
   shipColor:
     _useConstant: 1
     _constant: {r: 1, g: 0.40000078, b: 0, a: 1}
     _variable: {fileID: 0}
   maxHealth:
     _useConstant: 1
-    _constant: 75
+    _constant: 25
     _variable: {fileID: 0}
   maxShield:
     _useConstant: 1
-    _constant: 15
+    _constant: 0
     _variable: {fileID: 0}
   shieldRegen:
     _useConstant: 1
@@ -63,9 +63,9 @@ MonoBehaviour:
     _variable: {fileID: 0}
   dropMinMaxCount:
     _useConstant: 1
-    _constant: {x: 3, y: 8}
+    _constant: {x: 3, y: 5}
     _variable: {fileID: 0}
-  shellDrop: {fileID: 4108485770172352479, guid: 12680e9855c37684ea4f9c7f37017a4f, type: 3}
+  shellDrop: {fileID: 4108485770172352479, guid: 838fa67d6f45b6c47b3f66f0f226a072, type: 3}
   fire: {fileID: 0}
   hitSound: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Data/Attributes/Ships/Enemies/Purple Ship.asset
+++ b/Assets/Data/Attributes/Ships/Enemies/Purple Ship.asset
@@ -18,14 +18,14 @@ MonoBehaviour:
     _variable: {fileID: 0}
   description: 
   prefab: {fileID: 6812927983558368271, guid: 25d7f9715e358bb4eae872cd310d25f5, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_purple
   shipColor:
     _useConstant: 1
     _constant: {r: 0.644, g: 0, b: 1, a: 1}
     _variable: {fileID: 0}
   maxHealth:
     _useConstant: 1
-    _constant: 100
+    _constant: 50
     _variable: {fileID: 0}
   maxShield:
     _useConstant: 1
@@ -61,9 +61,9 @@ MonoBehaviour:
     _variable: {fileID: 0}
   dropMinMaxCount:
     _useConstant: 1
-    _constant: {x: 5, y: 10}
+    _constant: {x: 3, y: 5}
     _variable: {fileID: 0}
-  shellDrop: {fileID: 4108485770172352479, guid: 12680e9855c37684ea4f9c7f37017a4f, type: 3}
+  shellDrop: {fileID: 4108485770172352479, guid: 32c6949cf3591aa41b716444038cfa6a, type: 3}
   fire: {fileID: 11400000, guid: 550dd3e518aab5c45bdad97835ef007a, type: 2}
   hitSound: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Data/Attributes/Ships/Magenta Summon.asset
+++ b/Assets/Data/Attributes/Ships/Magenta Summon.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
     they lack in health is compensated by a small size with high mobility and fire
     rate.'
   prefab: {fileID: 8493826624106887132, guid: 5afee2896b7967146bdc19b6d17da531, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_magenta
   shipColor:
     _useConstant: 1
     _constant: {r: 0, g: 0, b: 0, a: 0}
@@ -80,7 +80,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   graphiteCostIncrease:
     _useConstant: 1
-    _constant: 15
+    _constant: 5
     _variable: {fileID: 0}
   maximumShips:
     _useConstant: 1

--- a/Assets/Data/Attributes/Ships/Mothership Attributes.asset
+++ b/Assets/Data/Attributes/Ships/Mothership Attributes.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   description: The Player Mothership
   prefab: {fileID: 52908406865915231, guid: 00046ec4a128db94db81d6518fe231f0, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_mother
   shipColor:
     _useConstant: 0
     _constant: {r: 0, g: 0, b: 0, a: 0}
@@ -45,7 +45,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   speed:
     _useConstant: 1
-    _constant: 5
+    _constant: 15
     _variable: {fileID: 0}
   defense:
     _useConstant: 1

--- a/Assets/Data/Attributes/Ships/Yellow Summon.asset
+++ b/Assets/Data/Attributes/Ships/Yellow Summon.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   description: Yellow ship summoned by the player
   prefab: {fileID: 1040831720659525790, guid: cc26e74262a8e9d47b4088dc58b31202, type: 3}
-  unlocalizedName: 
+  unlocalizedName: ship_yellow
   shipColor:
     _useConstant: 1
     _constant: {r: 0, g: 0, b: 0, a: 0}
@@ -45,7 +45,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   speed:
     _useConstant: 1
-    _constant: 5.5
+    _constant: 5
     _variable: {fileID: 0}
   defense:
     _useConstant: 1
@@ -81,7 +81,7 @@ MonoBehaviour:
     _variable: {fileID: 0}
   spawnCooldown:
     _useConstant: 1
-    _constant: 10
+    _constant: 8
     _variable: {fileID: 0}
   orbitRadius:
     _useConstant: 1

--- a/Assets/Data/Map/Difficulty Attributes.asset
+++ b/Assets/Data/Map/Difficulty Attributes.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   prefab: {fileID: 0}
   currentMap:
     _useConstant: 1
-    _constant: 1
+    _constant: 0
     _variable: {fileID: 0}
   currentDifficulty:
     _useConstant: 1
@@ -50,19 +50,19 @@ MonoBehaviour:
     _constant: {x: 0, y: 0}
     _variable: {fileID: 0}
   - _useConstant: 1
-    _constant: {x: 3, y: 6}
+    _constant: {x: 5, y: 8}
     _variable: {fileID: 0}
   - _useConstant: 1
-    _constant: {x: 6, y: 9}
+    _constant: {x: 8, y: 12}
     _variable: {fileID: 0}
   - _useConstant: 1
-    _constant: {x: 9, y: 12}
+    _constant: {x: 12, y: 16}
     _variable: {fileID: 0}
   - _useConstant: 1
-    _constant: {x: 3, y: 9}
+    _constant: {x: 16, y: 20}
     _variable: {fileID: 0}
   - _useConstant: 1
-    _constant: {x: 3, y: 9}
+    _constant: {x: 25, y: 25}
     _variable: {fileID: 0}
   mapHeight:
     _useConstant: 1

--- a/Assets/Prefabs/Other/Lime Pencil Shell.prefab
+++ b/Assets/Prefabs/Other/Lime Pencil Shell.prefab
@@ -1,0 +1,157 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4108485770172352479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8721439138124899955}
+  - component: {fileID: 373947945036896490}
+  - component: {fileID: 4713191707251145263}
+  - component: {fileID: 4618979822267471443}
+  - component: {fileID: 6701422747430550602}
+  m_Layer: 11
+  m_Name: Lime Pencil Shell
+  m_TagString: Drop
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8721439138124899955
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &373947945036896490
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 3c23a35f8cd73404488235a0cc7d2586, type: 3}
+  m_Color: {r: 0.5596056, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.15, y: 2.21}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &4713191707251145263
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.49, y: 0}
+  serializedVersion: 2
+  m_Radius: 2.78
+--- !u!114 &4618979822267471443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8da745683dba9e947b0fcd50f321d24d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+  shellWorth:
+    _useConstant: 1
+    _constant: 8
+    _variable: {fileID: 0}
+  collectEffect: {fileID: 0}
+  spinSpeed:
+    _useConstant: 0
+    _constant: 5
+    _variable: {fileID: 11400000, guid: 211f7a46d69c92543a16aac25dfda590, type: 2}
+  playerShells:
+    _useConstant: 0
+    _constant: 0
+    _variable: {fileID: 11400000, guid: d6a9e804e272a264290737db7ac36e9d, type: 2}
+  playerShellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+--- !u!50 &6701422747430550602
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Prefabs/Other/Lime Pencil Shell.prefab.meta
+++ b/Assets/Prefabs/Other/Lime Pencil Shell.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fad4cddbc0564f344aebf02278f79d7c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Other/Orange Pencil Shell.prefab
+++ b/Assets/Prefabs/Other/Orange Pencil Shell.prefab
@@ -1,0 +1,157 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4108485770172352479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8721439138124899955}
+  - component: {fileID: 373947945036896490}
+  - component: {fileID: 4713191707251145263}
+  - component: {fileID: 4618979822267471443}
+  - component: {fileID: 6701422747430550602}
+  m_Layer: 11
+  m_Name: Orange Pencil Shell
+  m_TagString: Drop
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8721439138124899955
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &373947945036896490
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 3c23a35f8cd73404488235a0cc7d2586, type: 3}
+  m_Color: {r: 1, g: 0.60045624, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.15, y: 2.21}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &4713191707251145263
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.49, y: 0}
+  serializedVersion: 2
+  m_Radius: 2.78
+--- !u!114 &4618979822267471443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8da745683dba9e947b0fcd50f321d24d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+  shellWorth:
+    _useConstant: 1
+    _constant: 1
+    _variable: {fileID: 0}
+  collectEffect: {fileID: 0}
+  spinSpeed:
+    _useConstant: 0
+    _constant: 5
+    _variable: {fileID: 11400000, guid: 211f7a46d69c92543a16aac25dfda590, type: 2}
+  playerShells:
+    _useConstant: 0
+    _constant: 0
+    _variable: {fileID: 11400000, guid: d6a9e804e272a264290737db7ac36e9d, type: 2}
+  playerShellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+--- !u!50 &6701422747430550602
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Prefabs/Other/Orange Pencil Shell.prefab.meta
+++ b/Assets/Prefabs/Other/Orange Pencil Shell.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 838fa67d6f45b6c47b3f66f0f226a072
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Other/Purple Pencil Shell.prefab
+++ b/Assets/Prefabs/Other/Purple Pencil Shell.prefab
@@ -1,0 +1,157 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4108485770172352479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8721439138124899955}
+  - component: {fileID: 373947945036896490}
+  - component: {fileID: 4713191707251145263}
+  - component: {fileID: 4618979822267471443}
+  - component: {fileID: 6701422747430550602}
+  m_Layer: 11
+  m_Name: Purple Pencil Shell
+  m_TagString: Drop
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8721439138124899955
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &373947945036896490
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 3c23a35f8cd73404488235a0cc7d2586, type: 3}
+  m_Color: {r: 0.5895567, g: 0, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.15, y: 2.21}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &4713191707251145263
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.49, y: 0}
+  serializedVersion: 2
+  m_Radius: 2.78
+--- !u!114 &4618979822267471443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8da745683dba9e947b0fcd50f321d24d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+  shellWorth:
+    _useConstant: 1
+    _constant: 2
+    _variable: {fileID: 0}
+  collectEffect: {fileID: 0}
+  spinSpeed:
+    _useConstant: 0
+    _constant: 5
+    _variable: {fileID: 11400000, guid: 211f7a46d69c92543a16aac25dfda590, type: 2}
+  playerShells:
+    _useConstant: 0
+    _constant: 0
+    _variable: {fileID: 11400000, guid: d6a9e804e272a264290737db7ac36e9d, type: 2}
+  playerShellColor:
+    _useConstant: 0
+    _constant: {r: 0, g: 0, b: 0, a: 0}
+    _variable: {fileID: 11400000, guid: 1bc42a043e5678149974e3c5e32d0cc5, type: 2}
+--- !u!50 &6701422747430550602
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4108485770172352479}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Prefabs/Other/Purple Pencil Shell.prefab.meta
+++ b/Assets/Prefabs/Other/Purple Pencil Shell.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32c6949cf3591aa41b716444038cfa6a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -11540,7 +11540,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -412, y: -420}
+  m_AnchoredPosition: {x: -412, y: -416}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1478666402
@@ -12553,7 +12553,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -412, y: -200.00006}
+  m_AnchoredPosition: {x: -412, y: -176}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1682095146
@@ -12630,7 +12630,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 80}
+  m_AnchoredPosition: {x: 0, y: 102}
   m_SizeDelta: {x: 320, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1686626327
@@ -13987,7 +13987,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -80}
+  m_AnchoredPosition: {x: 0, y: -34}
   m_SizeDelta: {x: 320, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1896986546
@@ -14968,7 +14968,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -412, y: -310.0001}
+  m_AnchoredPosition: {x: -412, y: -297}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2037773070


### PR DESCRIPTION
- Heavily increases the amount of waves of all planets
- Greatly decreases Orange Ship health, it can be killed with one shot of the Mothership now
- Increases the amount of shield for the Cyan Ship
- Creates one coin for each enemy
- Balances the amount of coins dropped by enemies as well as the value for each coin
- Increases Mothership speed by a lot
- Fixes button alignment in the in-game win menu